### PR TITLE
widen modals on mobile

### DIFF
--- a/src/scss/_buttons.scss
+++ b/src/scss/_buttons.scss
@@ -253,3 +253,12 @@ input:-internal-autofill-selected {
     bottom: 0;
   }
 }
+
+@media screen and (max-width: 580px) {
+  .axn {
+    &-btn {
+      text-transform: none !important;
+      font-size: 0.8rem !important;
+    }
+  }
+}

--- a/src/scss/_dialog.scss
+++ b/src/scss/_dialog.scss
@@ -190,4 +190,8 @@
   .dialog-block {
     height: 100%;
   }
+
+  .cdk-overlay-pane {
+    max-width: 95% !important;
+  }
 }


### PR DESCRIPTION
Made modals a bit wider on mobile with less margins on each side to make room for more content. The modal with 3 buttons was especially crowded and the buttons looked weird.