### PR TITLE
Disable Stake Upgrade if Already Max

### DIFF
--- a/src/app/pages/staking-page/staking-page.component.html
+++ b/src/app/pages/staking-page/staking-page.component.html
@@ -492,7 +492,7 @@
 
           <!-- Extend Stake -->
           <td class="action-button" *ngIf="maxSharesActive">
-            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress || stake.length === +maxShareMaxDays">
+            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress || stake.length > +maxShareMaxDays">
               <span class="t-fw-light">&nbsp;&nbsp;UPGRADE&nbsp;&nbsp;</span>
             </button>
           </td>

--- a/src/app/pages/staking-page/staking-page.component.html
+++ b/src/app/pages/staking-page/staking-page.component.html
@@ -651,7 +651,7 @@
 
           <!-- Extend Stake -->
           <td class="action-button" *ngIf="maxSharesActive">
-            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress || stake.length === stakeMaxDays">
+            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress || stake.length > +maxShareMaxDays">
               <span class="t-fw-light">&nbsp;&nbsp;UPGRADE&nbsp;&nbsp;</span>
             </button>
           </td>

--- a/src/app/pages/staking-page/staking-page.component.html
+++ b/src/app/pages/staking-page/staking-page.component.html
@@ -492,7 +492,7 @@
 
           <!-- Extend Stake -->
           <td class="action-button" *ngIf="maxSharesActive">
-            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress">
+            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress || stake.length === stakeMaxDays">
               <span class="t-fw-light">&nbsp;&nbsp;UPGRADE&nbsp;&nbsp;</span>
             </button>
           </td>
@@ -651,7 +651,7 @@
 
           <!-- Extend Stake -->
           <td class="action-button" *ngIf="maxSharesActive">
-            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress">
+            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress || stake.length === stakeMaxDays">
               <span class="t-fw-light">&nbsp;&nbsp;UPGRADE&nbsp;&nbsp;</span>
             </button>
           </td>

--- a/src/app/pages/staking-page/staking-page.component.html
+++ b/src/app/pages/staking-page/staking-page.component.html
@@ -492,7 +492,7 @@
 
           <!-- Extend Stake -->
           <td class="action-button" *ngIf="maxSharesActive">
-            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress || stake.length === stakeMaxDays">
+            <button class="axn-btn axn-btn-gray" (click)="extendStake(stake)" [disabled]="extensionInfo.progress || stake.length === +maxShareMaxDays">
               <span class="t-fw-light">&nbsp;&nbsp;UPGRADE&nbsp;&nbsp;</span>
             </button>
           </td>

--- a/src/app/pages/staking-page/staking-page.component.ts
+++ b/src/app/pages/staking-page/staking-page.component.ts
@@ -132,6 +132,7 @@ export class StakingPageComponent implements OnDestroy {
   private dayEndSubscriber;
 
   private usdcPerAxnPrice;
+  public maxShareMaxDays;
 
   constructor(
     private contractService: ContractService,
@@ -164,6 +165,7 @@ export class StakingPageComponent implements OnDestroy {
                 this.bpdInfoChecker = true;
               });
 
+              this.maxShareMaxDays = await this.contractService.getMaxDaysMaxShares();
               this.maxSharesActive = await this.contractService.checkMaxSharesActive();
               this.usdcPerAxnPrice = await this.contractService.getUsdcPerAxnPrice();
             }

--- a/src/app/services/contract/index.ts
+++ b/src/app/services/contract/index.ts
@@ -2028,4 +2028,8 @@ export class ContractService {
   public extendStake(stake: Stake) {
     return this.StakingContract.methods[stake.isV1 ? "maxShareV1" : "maxShare"](stake.sessionId).send({ from: this.account.address })
   }
+
+  public getMaxDaysMaxShares() {
+    return this.StakingContract.methods.getMaxShareMaxDays().call()
+  }
 }

--- a/src/app/services/contract/index.ts
+++ b/src/app/services/contract/index.ts
@@ -33,6 +33,7 @@ export interface Stake {
   isWithdrawn: boolean;
   isV1: boolean;
   apy: number;
+  length: number;
 }
 
 export interface Auction {
@@ -1229,7 +1230,9 @@ export class ContractService {
         )
         .call();
 
+      const startMs = stakeSession.start * 1000;
       const endMs = stakeSession.end * 1000;
+      const dayMs = this.settingsApp.settings.time.seconds * 1000;
       const amount = new BigNumber(stakeSession.amount);
       const bigPayDay = new BigNumber(bigPayDayPayout[0]);
 
@@ -1255,7 +1258,8 @@ export class ContractService {
         isBpdWithdraw: stakeSession.withdrawn && !bigPayDay.isZero(),
         isBpdWithdrawn: bpdSession.withdrawn,
         isV1: true,
-        apy: 0
+        apy: 0,
+        length: (endMs - startMs) / dayMs
       };
 
       return stake;
@@ -1282,7 +1286,9 @@ export class ContractService {
         )
         .call();
 
+      const startMs = stakeSession.start * 1000;
       const endMs = stakeSession.end * 1000;
+      const dayMs = this.settingsApp.settings.time.seconds * 1000;
       const amount = new BigNumber(stakeSession.amount);
       const bigPayDay = new BigNumber(bigPayDayPayout[0]);
 
@@ -1305,7 +1311,8 @@ export class ContractService {
         isBpdWithdraw: stakeSession.withdrawn && !bigPayDay.isZero(),
         isBpdWithdrawn: bpdSession.withdrawn,
         isV1: false,
-        apy: 0
+        apy: 0,
+        length: (endMs - startMs) / dayMs
       };
 
       return stake;

--- a/src/assets/js/constants.json
+++ b/src/assets/js/constants.json
@@ -4812,6 +4812,19 @@
           "outputs": [],
           "stateMutability": "nonpayable",
           "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "getMaxShareMaxDays",
+          "outputs": [
+            {
+              "internalType": "uint16",
+              "name": "_maxShareMaxDays",
+              "type": "uint16"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
         }
       ]
     },
@@ -17637,6 +17650,19 @@
           "name": "unstakeV1",
           "outputs": [],
           "stateMutability": "nonpayable",
+          "type": "function"
+        },
+        {
+          "inputs": [],
+          "name": "getMaxShareMaxDays",
+          "outputs": [
+            {
+              "internalType": "uint16",
+              "name": "_maxShareMaxDays",
+              "type": "uint16"
+            }
+          ],
+          "stateMutability": "view",
           "type": "function"
         }
       ]


### PR DESCRIPTION
If the upgrade button is confirmed staying, this PR addresses the slight change of not being able to upgrade a stake if its already max shares. 